### PR TITLE
Fix race in WindowAutomationWorkerIT.shouldHandleExceptionsDuringInitialization

### DIFF
--- a/src/test/java/com/lr/business/WindowAutomationWorkerIT.java
+++ b/src/test/java/com/lr/business/WindowAutomationWorkerIT.java
@@ -304,6 +304,7 @@ class WindowAutomationWorkerIT {
         // When
         workerThread.start();
         boolean finished = workerFinished.await(3, TimeUnit.SECONDS);
+        workerThread.join(1000);
 
         // Then
         assertTrue(finished, "Worker should terminate gracefully even after initialization error");


### PR DESCRIPTION
## Summary
- Latest CI on `main` fails on `WindowAutomationWorkerIT.shouldHandleExceptionsDuringInitialization` (Build & Test → Run Integration Tests). Because the `Security Scan` job has `needs: build-and-test`, the OWASP dependency-check **never runs on main** — the project has been effectively security-blind despite recent Dependabot bumps.
- Root cause is a race in the test, not a regression in the worker: it awaits a `CountDownLatch` decremented from the worker's `finally` block, then asserts `workerThread.isAlive() == false`. The latch fires before the JVM transitions the thread to `TERMINATED`, so `isAlive()` can still return true. The worker itself catches `AWTException` and exits cleanly.
- Fix: add a bounded `workerThread.join(1000)` before the `isAlive()` assertion.

## Follow-ups (not in this PR)
- Dependabot's **security-updates** job is failing on every run with `Error during file fetching; aborting: /home/runner/work/ChaosBot/ChaosBot not found` — GitHub is passing the absolute checkout path as the directory for security updates while version updates correctly use `/`. The advisory list in the failing job includes real CVEs in netty (multiple), spring-boot, spring-webflux, bouncycastle, jackson, and assertj. Repo currently shows **28 open vulnerability alerts** (1 critical, 14 high). Worth a separate ticket: try adding `directories: ["/"]` (plural) to `.github/dependabot.yml`, or pin patched transitive versions directly in `pom.xml` as an immediate mitigation.
- The sibling test `shouldHandleInterrupt` (line 277) uses the same latch-then-isAlive pattern; it hasn't flaked, but it's racy in principle.

## Test plan
- [ ] CI green on Build and Test
- [ ] `Security Scan` job actually runs (was being skipped due to upstream failure) and either passes or surfaces concrete CVEs to triage