### PR TITLE
Add explicit security-updates group to Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,7 @@ updates:
           - "minor"
           - "patch"
           - "major"
+      security:
+        applies-to: security-updates
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- Every Dependabot **security-updates** run on this repo fails with `Error during file fetching; aborting: /home/runner/work/ChaosBot/ChaosBot not found` — the job spec contains `"directories":["/home/runner/work/ChaosBot/ChaosBot"]`, while parallel version-updates runs in the same hour correctly resolve to `/`. As a result, the **28 open Dependabot alerts** (1 critical, 14 high, 9 moderate, 4 low — netty, spring-boot, spring-webflux, bouncycastle, jackson, assertj) are not being auto-patched.
- The config previously only defined a group for `version-updates`, so security updates fell back to GitHub's auto-injected default group, which expands `directory: "/"` to the absolute checkout path.
- Fix: add an explicit `security-updates` group so Dependabot has an unambiguous resolution context.

## Verifying
Dependabot evaluates `dependabot.yml` on push to default branch. After merge, force a security run from the Insights → Dependency graph → Dependabot tab (or wait for the next scheduled run) and confirm the new job description reads `maven in /` rather than `maven in /home/runner/work/...`.

## Test plan
- [ ] After merge, next security-updates run resolves directory to `/` and completes successfully
- [ ] One or more security PRs open against the actual CVE list (netty 4.1.x → ≥4.1.132.Final, spring-boot → 4.0.6, etc.)