### PR TITLE
Fix OWASP OSS Index auth: bind creds via ${env.X} in pom

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -148,13 +148,15 @@ jobs:
     - name: Run OWASP Dependency Check
       run: mvn -B org.owasp:dependency-check-maven:check
       env:
-        # Security credentials (passed via environment variables, not command line)
+        # Credentials are read directly from these env vars by pom.xml
+        # via Maven's ${env.X} interpolation. Do NOT bake them into
+        # MAVEN_OPTS — ${VAR} inside a YAML env: value is a literal
+        # string, not a shell expansion.
         NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
         OSS_INDEX_USERNAME: ${{ secrets.OSS_INDEX_USERNAME }}
         OSS_INDEX_PASSWORD: ${{ secrets.OSS_INDEX_PASSWORD }}
-        # Performance optimizations and secure credentials via environment
-        MAVEN_OPTS: "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=WARN -DnvdApiKey=${NVD_API_KEY} -DossIndexUsername=${OSS_INDEX_USERNAME} -DossIndexPassword=${OSS_INDEX_PASSWORD}"
-        
+        MAVEN_OPTS: "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=WARN"
+
 
     - name: Upload Security Report
       uses: actions/upload-artifact@v4

--- a/pom.xml
+++ b/pom.xml
@@ -134,13 +134,13 @@
                     </formats>
                     <prettyPrint>true</prettyPrint>
                     <!-- NVD API Configuration (NIST) -->
-                    <nvdApiKey>${nvdApiKey}</nvdApiKey>
+                    <nvdApiKey>${env.NVD_API_KEY}</nvdApiKey>
                     <nvdMaxRetryCount>10</nvdMaxRetryCount>
                     <nvdApiDelay>2000</nvdApiDelay>
                     <nvdValidForHours>24</nvdValidForHours>
                     <!-- OSS Index Configuration (Sonatype) -->
-                    <ossIndexUsername>${ossIndexUsername}</ossIndexUsername>
-                    <ossIndexPassword>${ossIndexPassword}</ossIndexPassword>
+                    <ossIndexUsername>${env.OSS_INDEX_USERNAME}</ossIndexUsername>
+                    <ossIndexPassword>${env.OSS_INDEX_PASSWORD}</ossIndexPassword>
                     <!-- Performance optimizations -->
                     <dataDirectory>~/.dependency-check/data</dataDirectory>
                     <connectionTimeout>60000</connectionTimeout>


### PR DESCRIPTION
## Summary
- The Sonatype OSS Index login has been failing because the plugin was reading the **literal strings** `${ossIndexUsername}` / `${ossIndexPassword}`, not your actual token. Rotating tokens couldn't fix it — the tokens never reached the plugin.
- Cause: the workflow tried to wire creds through `MAVEN_OPTS`:
  ```yaml
  MAVEN_OPTS: "-DossIndexUsername=${OSS_INDEX_USERNAME} ..."
  ```
  GitHub Actions doesn't shell-expand `${VAR}` inside `env:` values — only `${{ }}` expressions are evaluated. So `MAVEN_OPTS` reached the JVM with the placeholders intact, and Sonatype 401'd.
- Fix, per the [rieckpil.de OWASP OSS Index guide](https://rieckpil.de/fix-sonatype-oss-index-errors-for-owasp-maven-plugin/): bind the values in `pom.xml` using Maven's native `${env.X}` interpolation and drop the broken `MAVEN_OPTS` substitution. NVD_API_KEY migrated the same way.
- Plugin version 12.2.2 already satisfies the guide's ≥12.x requirement, no bump needed.

## What changed
- `pom.xml`: `${ossIndexUsername}` → `${env.OSS_INDEX_USERNAME}`, `${ossIndexPassword}` → `${env.OSS_INDEX_PASSWORD}`, `${nvdApiKey}` → `${env.NVD_API_KEY}`.
- `.github/workflows/maven.yml`: removed the `-DossIndex... -DnvdApiKey...` from `MAVEN_OPTS` (kept the slf4j logger flag). The step still exports `OSS_INDEX_USERNAME` / `OSS_INDEX_PASSWORD` / `NVD_API_KEY` from secrets — that's all the pom needs now.

## Stacking
This sits on top of #22 (test race fix). Until #22 lands, the Security Scan job is still gated behind a failing IT and won't actually exercise this change.

## Test plan
- [ ] After merge of #22 + this, the Security Scan job runs and OSS Index analysis succeeds (no 401, no `${...}` literals in the dependency-check report)
- [ ] CVE counts in the report look reasonable (we expect non-zero given the 28 open Dependabot alerts)