### PR TITLE
Pin transitive deps to patched versions for open Dependabot alerts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -196,6 +196,52 @@
         <tag>HEAD</tag>
   </scm>
 
+    <!--
+        Pin transitive dependencies to patched versions for Dependabot alerts
+        that are not yet absorbed by spring-boot-starter-parent. These overrides
+        take precedence over the parent BOM's management.
+    -->
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>4.2.13.Final</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-framework-bom</artifactId>
+                <version>7.0.7</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>tools.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>3.1.3</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcprov-jdk18on</artifactId>
+                <version>1.84</version>
+            </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcpkix-jdk18on</artifactId>
+                <version>1.84</version>
+            </dependency>
+            <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>3.27.7</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.openpnp</groupId>


### PR DESCRIPTION
## Summary
Closes the 27 still-open Dependabot alerts on `main` (1 was already fixed by the parent bump in #20) by adding a `<dependencyManagement>` section that imports patched BOMs and pins a few direct overrides. All entries take precedence over `spring-boot-starter-parent`'s BOM, so Spring Boot itself stays on 4.0.6 while transitive deps get pulled up to safe versions.

## Coverage

| Pin | Severity → fixed | CVEs |
|---|---|---|
| `io.netty:netty-bom 4.2.13.Final` (BOM) | 1×low, 3×med, 6×high | CVE-2026-33870, -33871, -41417, -42577..42587, GHSA-pwqr-wmgm-9rr8 |
| `org.springframework:spring-framework-bom 7.0.7` (BOM) | 3×low, 2×med | CVE-2026-22735, -22737, -22740, -22741, -22745 |
| `tools.jackson:jackson-bom 3.1.3` (BOM) | 1×med, 1×high | CVE-2026-29062, GHSA-2m67-wjpj-xhg9, GHSA-72hv-8253-57qq |
| `org.bouncycastle:bcprov-jdk18on 1.84` | 1×med, 1×high | CVE-2026-0636, CVE-2026-5598 |
| `org.bouncycastle:bcpkix-jdk18on 1.84` | 1×med | CVE-2026-5588 |
| `org.assertj:assertj-core 3.27.7` (test scope) | 1×high | CVE-2026-24400 |

The **critical** alert (`CVE-2026-40976` / `GHSA-8v8j-3hxp-93wr` against `spring-boot < 4.0.6`) is already fixed by Dependabot PR #20 which bumped the parent to 4.0.6 — Dependabot should auto-close it on the next scan.

## Verifying
CI exercises every replaced transitive: the webflux Discord client, Tess4J/jackson serialization, and the full IT suite. If a 7.0.6 → 7.0.7 or 4.2.12 → 4.2.13 bump breaks anything binary-level, integration tests should catch it. After merge, the next OWASP scan (now correctly authenticating to OSS Index, post #24) and Dependabot rescan should show the alert count drop to zero.

## Test plan
- [ ] CI green (unit + integration)
- [ ] Next Dependabot scan auto-closes the 27 alerts in scope; no new alerts from the bumped versions
- [ ] OWASP `dependency-check-report.json` shows no failOnCVSS≥7 hits