### PR TITLE
Set workflow-level least-privilege GITHUB_TOKEN permissions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -14,6 +14,11 @@ on:
   pull_request:
     branches: [ "**" ]  # Trigger on PRs to any branch
 
+# Default least-privilege token for every job. The security-scan job
+# overrides this with `contents: write` to submit the dependency graph.
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     name: Build and Test


### PR DESCRIPTION
## Summary
CodeQL flagged two open alerts (medium security severity) against \`.github/workflows/maven.yml\`:
- Alert #2 — \`build-and-test\` job (lines 19–80) — no explicit \`permissions\`
- Alert #3 — \`code-quality\` job (lines 81–111) — no explicit \`permissions\`

Rule: [actions/missing-workflow-permissions](https://codeql.github.com/codeql-query-help/actions/actions-missing-workflow-permissions/). Without an explicit block the workflow inherits the repo default, which on older repos is read/write — way more than these jobs need.

Fix: add a workflow-level \`permissions: contents: read\` so all jobs inherit least privilege. The \`security-scan\` job's existing per-job \`permissions: contents: write\` override (needed by the dependency-graph submission action) is preserved.

## Test plan
- [ ] CI green
- [ ] After merge, the two CodeQL alerts auto-close on next scan